### PR TITLE
Use stdin for specifying image tags to upgrade strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ would look for the same keys as it did for `filename` and update the relevant ke
 
 #### 2. `upgrade_strategy`
 
-`upgrade_strategy` is an executable file which should accept the following format as input:
+`upgrade_strategy` is an executable file which should accept the following format as input via stdin:
 
 ```
 {


### PR DESCRIPTION
## Problem

Some docker images can have thousands of tags which make us run into `Argument list too long` error as we start hitting `ARG_MAX `.

## Solution

Instead of passing the docker image tags as arguments to `upgrade_strategy`, we now pass the tags via `stdin` so as to avoid hitting this limit.