### PR TITLE
Preserve comments/indents in chart.yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ catalog_validation
 jsonschema
 python-dotenv
 pyyaml
+ruamel.yaml


### PR DESCRIPTION
## Problem

`pyyaml` is not preserving comments/indents specified in `Chart.yaml` for apps which results in inconsistencies and losing comments explaining/outlining reasons for various behaviours.

## Solution

Using `ruamel.yaml` solves the problem and we are able to preserve comments/indents nicely